### PR TITLE
#8162 changed field type psj_publisher

### DIFF
--- a/psj/content/behaviors.py
+++ b/psj/content/behaviors.py
@@ -401,10 +401,9 @@ class IPSJEdition(IPSJBehavior):
         fields=('psj_publisher', 'psj_isbn_issn'),
         )
 
-    psj_publisher = Choice(
+    psj_publisher = TextLine(
         title=_(u'Verlag'),
         description=u'',
-        source=publishers_source,
         required=False,
         )
 


### PR DESCRIPTION
Make psj_publisher type textline.

Fixes #8162, pulls-in changes from @clamor
